### PR TITLE
Run CI and release builds on Node 24 (current LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
Bumps the GitHub Actions Node runtime from **20.x → 24.x** in both `ci.yml` and `release.yml`.

**Why:** Node 20 reached end-of-life (April 2026); 24.x is the current Active LTS. This only affects the build/test/release tooling on GitHub Actions — it does **not** change the plugin's actual runtime (that's whatever Node the user's Obsidian/Electron ships). Also brings the CI runtime closer to the `@types/node@25` we now depend on.

**Validation:** this PR's own CI run exercises `npm run check` + `npm run build` on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)