### PR TITLE
Mobile support + better-result error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Notion / Linear-style **margin comments** for Obsidian — except the comments l
 
 ![Document Comments — threaded comment cards in the right margin of an Obsidian note](screenshot.png)
 
-> **Desktop-only.** Available in Obsidian's **Community plugins** store — see [Install](#install).
+> Available in Obsidian's **Community plugins** store, on **desktop and mobile** — see [Install](#install).
 
 ## Features
 
@@ -13,9 +13,10 @@ Notion / Linear-style **margin comments** for Obsidian — except the comments l
 - **Threads, resolve / reopen, emoji reactions, edit & delete** — every action is a plain edit to the markdown, so it round-trips cleanly.
 - **Markdown in comment text** — code spans, bold, links, lists, etc. render in the cards (margin and sidebar).
 - **Long comments collapse** to a *Show more* preview; a thread taller than the screen opens in the sidebar instead.
-- **Inline composer.** Select text → command or right-click → a draft card opens in the margin (no modal).
+- **Inline composer.** Select text → command or right-click → a draft card opens in the margin (no modal). On mobile, a small dialog takes its place.
 - **"All discussions" sidebar** — a panel listing the active note's comments with **Open / Resolved / All** filter tabs; while it's open the inline cards step aside (the in-text highlights stay).
 - **Toggle comments** on/off (also hides the text highlights), and **hide resolved** comments by default.
+- **Mobile.** On phones and tablets the floating margin is turned off (there's no room for it): the in-text **highlights** still mark commented text, and you read, reply, and resolve through the **sidebar** panel — new comments are composed in a quick dialog. It's the same inline storage, so a note's comments are identical on desktop and mobile.
 
 ## How comments are stored
 
@@ -31,7 +32,7 @@ sam (2026-06-17T10:05:00.000Z): Thursday is better for QA.
 
 ## Install
 
-Requires **Obsidian 1.7.2 or newer**, desktop.
+Requires **Obsidian 1.7.2 or newer** (desktop or mobile).
 
 ### Community plugins (recommended)
 
@@ -80,7 +81,7 @@ No network use, no telemetry, no accounts. Everything stays in your vault.
 
 ## Known limitations
 
-- **Desktop-only** for now — the margin column needs the horizontal space. A mobile / narrow-screen layout is planned.
+- On **mobile**, the floating margin column is turned off (there's no room for it). Comments are read and managed through the **sidebar** instead — highlights still mark the text, and new comments are composed in a dialog. Same inline storage, so it round-trips with desktop.
 - Comments whose highlighted text **overlaps** another comment's are stored fine but are a rough edge; avoid stacking comments on the same words for now.
 - In **Live Preview**, the highlight doesn't show on text inside a **table** (Obsidian renders tables as a self-contained widget the highlight can't reach). The comment and its card still work, and the highlight shows in **Reading view** and **Source mode**.
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,5 @@
 	"minAppVersion": "1.7.2",
 	"description": "Notion-style margin comments stored inline in your markdown, so agents and other tools can read them too.",
 	"author": "Kyle McDonald",
-	"isDesktopOnly": true
+	"isDesktopOnly": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "document-comments",
 			"version": "0.1.0",
 			"license": "MIT",
+			"dependencies": {
+				"better-result": "^2.9.2"
+			},
 			"devDependencies": {
 				"@codemirror/state": "^6.6.0",
 				"@codemirror/view": "^6.43.1",
@@ -1595,9 +1598,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1615,9 +1615,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1635,9 +1632,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1655,9 +1649,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1675,9 +1666,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1695,9 +1683,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2501,6 +2486,12 @@
 			"engines": {
 				"node": "18 || 20 || >=22"
 			}
+		},
+		"node_modules/better-result": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/better-result/-/better-result-2.9.2.tgz",
+			"integrity": "sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q==",
+			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
 			"version": "5.0.6",
@@ -4993,9 +4984,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5017,9 +5005,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5041,9 +5026,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5065,9 +5047,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
 		"typescript": "^6.0.3",
 		"typescript-eslint": "^8.61.1",
 		"vitest": "^4.1.8"
+	},
+	"dependencies": {
+		"better-result": "^2.9.2"
 	}
 }

--- a/src/editor/commands.ts
+++ b/src/editor/commands.ts
@@ -1,7 +1,9 @@
+import type { App, TFile } from "obsidian";
 import { EditorView } from "@codemirror/view";
 import { existingIds } from "../format/parse";
 import { generateId } from "../format/ids";
 import {
+	applyChanges,
 	computeAddComment,
 	computeAppendReply,
 	computeDeleteComment,
@@ -19,6 +21,28 @@ export const addComment = (view: EditorView, from: number, to: number, text: str
 	if (!changes) return null;
 	view.dispatch({ changes, scrollIntoView: false });
 	return id;
+};
+
+/** Write a brand-new comment straight to a file on disk — for surfaces with no
+ *  live CodeMirror view (reading view, and mobile where the margin composer is
+ *  off). Returns the new id, or null if the range produced no change. */
+export const insertCommentInFile = async (
+	app: App,
+	file: TFile,
+	from: number,
+	to: number,
+	text: string,
+	author: string,
+): Promise<string | null> => {
+	let newId: string | null = null;
+	await app.vault.process(file, (data) => {
+		const id = generateId(existingIds(data));
+		const changes = computeAddComment(data, from, to, { id, createdAt: now(), author, text });
+		if (!changes) return data;
+		newId = id;
+		return applyChanges(data, changes);
+	});
+	return newId;
 };
 
 export const appendReply = (view: EditorView, id: string, text: string, author: string): boolean => {

--- a/src/editor/commands.ts
+++ b/src/editor/commands.ts
@@ -1,4 +1,5 @@
 import type { App, TFile } from "obsidian";
+import { Result } from "better-result";
 import { EditorView } from "@codemirror/view";
 import { existingIds } from "../format/parse";
 import { generateId } from "../format/ids";
@@ -13,19 +14,61 @@ import {
 	computeToggleReaction,
 } from "./edits";
 
-/** Wrap the range with anchor markers and append a body block; returns the new id. */
-export const addComment = (view: EditorView, from: number, to: number, text: string, author: string): string | null => {
+/** Wrap the range with anchor markers and append a body block; ok carries the new id. */
+export const addComment = (
+	view: EditorView,
+	from: number,
+	to: number,
+	text: string,
+	author: string,
+): Result<string, string> => {
 	const doc = view.state.doc.toString();
 	const id = generateId(existingIds(doc));
-	const changes = computeAddComment(doc, from, to, { id, createdAt: now(), author, text });
-	if (!changes) return null;
-	view.dispatch({ changes, scrollIntoView: false });
-	return id;
+	return computeAddComment(doc, from, to, { id, createdAt: now(), author, text }).map((changes) => {
+		view.dispatch({ changes, scrollIntoView: false });
+		return id;
+	});
+};
+
+export const appendReply = (view: EditorView, id: string, text: string, author: string): Result<void, string> => {
+	return computeAppendReply(view.state.doc.toString(), id, { createdAt: now(), author, text }).map((changes) => {
+		view.dispatch({ changes });
+	});
+};
+
+export const setResolved = (view: EditorView, id: string, resolved: boolean): Result<void, string> => {
+	return computeSetResolved(view.state.doc.toString(), id, resolved).map((changes) => {
+		view.dispatch({ changes });
+	});
+};
+
+export const deleteComment = (view: EditorView, id: string): Result<void, string> => {
+	return computeDeleteComment(view.state.doc.toString(), id).map((changes) => {
+		view.dispatch({ changes });
+	});
+};
+
+export const editEntry = (view: EditorView, id: string, index: number, text: string): Result<void, string> => {
+	return computeEditEntry(view.state.doc.toString(), id, index, text).map((changes) => {
+		view.dispatch({ changes });
+	});
+};
+
+export const deleteEntry = (view: EditorView, id: string, index: number): Result<void, string> => {
+	return computeDeleteEntry(view.state.doc.toString(), id, index).map((changes) => {
+		view.dispatch({ changes });
+	});
+};
+
+export const toggleReaction = (view: EditorView, id: string, emoji: string, author: string): Result<void, string> => {
+	return computeToggleReaction(view.state.doc.toString(), id, emoji, author).map((changes) => {
+		view.dispatch({ changes });
+	});
 };
 
 /** Write a brand-new comment straight to a file on disk — for surfaces with no
  *  live CodeMirror view (reading view, and mobile where the margin composer is
- *  off). Returns the new id, or null if the range produced no change. */
+ *  off). Ok carries the new id; Err carries a reason (I/O failure or empty range). */
 export const insertCommentInFile = async (
 	app: App,
 	file: TFile,
@@ -33,58 +76,24 @@ export const insertCommentInFile = async (
 	to: number,
 	text: string,
 	author: string,
-): Promise<string | null> => {
-	let newId: string | null = null;
-	await app.vault.process(file, (data) => {
-		const id = generateId(existingIds(data));
-		const changes = computeAddComment(data, from, to, { id, createdAt: now(), author, text });
-		if (!changes) return data;
-		newId = id;
-		return applyChanges(data, changes);
+): Promise<Result<string, string>> => {
+	let computed: Result<string, string> = Result.err("No change was written.");
+	const io = await Result.tryPromise({
+		try: () =>
+			app.vault.process(file, (data) => {
+				const id = generateId(existingIds(data));
+				const result = computeAddComment(data, from, to, { id, createdAt: now(), author, text });
+				if (result.isErr()) {
+					computed = Result.err(result.error);
+					return data;
+				}
+				computed = Result.ok(id);
+				return applyChanges(data, result.value);
+			}),
+		catch: (e) => (e instanceof Error ? e.message : "unknown error"),
 	});
-	return newId;
-};
-
-export const appendReply = (view: EditorView, id: string, text: string, author: string): boolean => {
-	const changes = computeAppendReply(view.state.doc.toString(), id, { createdAt: now(), author, text });
-	if (!changes) return false;
-	view.dispatch({ changes });
-	return true;
-};
-
-export const setResolved = (view: EditorView, id: string, resolved: boolean): boolean => {
-	const changes = computeSetResolved(view.state.doc.toString(), id, resolved);
-	if (!changes) return false;
-	view.dispatch({ changes });
-	return true;
-};
-
-export const deleteComment = (view: EditorView, id: string): boolean => {
-	const changes = computeDeleteComment(view.state.doc.toString(), id);
-	if (!changes) return false;
-	view.dispatch({ changes });
-	return true;
-};
-
-export const editEntry = (view: EditorView, id: string, index: number, text: string): boolean => {
-	const changes = computeEditEntry(view.state.doc.toString(), id, index, text);
-	if (!changes) return false;
-	view.dispatch({ changes });
-	return true;
-};
-
-export const deleteEntry = (view: EditorView, id: string, index: number): boolean => {
-	const changes = computeDeleteEntry(view.state.doc.toString(), id, index);
-	if (!changes) return false;
-	view.dispatch({ changes });
-	return true;
-};
-
-export const toggleReaction = (view: EditorView, id: string, emoji: string, author: string): boolean => {
-	const changes = computeToggleReaction(view.state.doc.toString(), id, emoji, author);
-	if (!changes) return false;
-	view.dispatch({ changes });
-	return true;
+	// Surface an I/O failure; otherwise the compute outcome (id, or the reason nothing was written).
+	return io.isErr() ? Result.err(io.error) : computed;
 };
 
 const now = (): string => {

--- a/src/editor/config.ts
+++ b/src/editor/config.ts
@@ -16,6 +16,10 @@ export type CommentConfig = {
 	sidebarOpen: () => boolean;
 	/** Reveal a thread in the sidebar — used by a margin card too tall to fit. */
 	openInSidebar?: (id: string) => void;
+	/** True on Obsidian mobile. The floating margin column needs horizontal room
+	 *  mobile doesn't have, so there it's suppressed (text stays full-width) and
+	 *  comments live in the sidebar panel instead; the in-text highlights remain. */
+	isMobile?: () => boolean;
 };
 
 const DEFAULT: CommentConfig = {

--- a/src/editor/edits.ts
+++ b/src/editor/edits.ts
@@ -1,3 +1,4 @@
+import { Result } from "better-result";
 import { CommentData, ParsedComment, Reaction } from "../format/types";
 import { parseComments } from "../format/parse";
 import { closeMarker, openMarker, serializeBody } from "../format/serialize";
@@ -16,10 +17,16 @@ export type NewCommentInput = {
 	text: string;
 };
 
-/** Wrap [from,to] with anchor markers and append a body block after the block. */
-export const computeAddComment = (doc: string, from: number, to: number, input: NewCommentInput): Change[] | null => {
+/** Wrap [from,to] with anchor markers and append a body block after the block.
+ *  Errs (rather than returning null) so the caller sees why nothing was written. */
+export const computeAddComment = (
+	doc: string,
+	from: number,
+	to: number,
+	input: NewCommentInput,
+): Result<Change[], string> => {
 	if (to < from) [from, to] = [to, from];
-	if (to === from) return null;
+	if (to === from) return Result.err("Select some text to comment on.");
 
 	const quote = doc.slice(from, to);
 	const data: CommentData = {
@@ -31,30 +38,30 @@ export const computeAddComment = (doc: string, from: number, to: number, input: 
 		reactions: [],
 	};
 	const paraEnd = blockEnd(doc, to);
-	return [
+	return Result.ok([
 		{ from, to: from, insert: openMarker(input.id) },
 		{ from: to, to, insert: closeMarker(input.id) },
 		{ from: paraEnd, to: paraEnd, insert: "\n" + serializeBody(input.id, data) },
-	];
+	]);
 };
 
 export const computeAppendReply = (
 	doc: string,
 	id: string,
 	entry: { createdAt: string; author: string; text: string },
-): Change[] | null => {
+): Result<Change[], string> => {
 	return replaceBody(doc, id, (c) => ({
 		...toData(c),
 		thread: [...c.thread, { author: entry.author, timestamp: entry.createdAt, text: entry.text }],
 	}));
 };
 
-export const computeSetResolved = (doc: string, id: string, resolved: boolean): Change[] | null => {
+export const computeSetResolved = (doc: string, id: string, resolved: boolean): Result<Change[], string> => {
 	return replaceBody(doc, id, (c) => ({ ...toData(c), status: resolved ? "resolved" : "open" }));
 };
 
 /** Replace the text of the i-th message in a thread. */
-export const computeEditEntry = (doc: string, id: string, index: number, text: string): Change[] | null => {
+export const computeEditEntry = (doc: string, id: string, index: number, text: string): Result<Change[], string> => {
 	return replaceBody(doc, id, (c) => ({
 		...toData(c),
 		thread: c.thread.map((e, i) => (i === index ? { ...e, text } : e)),
@@ -62,7 +69,7 @@ export const computeEditEntry = (doc: string, id: string, index: number, text: s
 };
 
 /** Remove the i-th message from a thread (used for replies). */
-export const computeDeleteEntry = (doc: string, id: string, index: number): Change[] | null => {
+export const computeDeleteEntry = (doc: string, id: string, index: number): Result<Change[], string> => {
 	return replaceBody(doc, id, (c) => ({
 		...toData(c),
 		thread: c.thread.filter((_, i) => i !== index),
@@ -70,14 +77,20 @@ export const computeDeleteEntry = (doc: string, id: string, index: number): Chan
 };
 
 /** Add/remove the author from an emoji reaction. */
-export const computeToggleReaction = (doc: string, id: string, emoji: string, author: string): Change[] | null => {
+export const computeToggleReaction = (
+	doc: string,
+	id: string,
+	emoji: string,
+	author: string,
+): Result<Change[], string> => {
 	return replaceBody(doc, id, (c) => ({ ...toData(c), reactions: toggleReactions(c.reactions, emoji, author) }));
 };
 
-const replaceBody = (doc: string, id: string, mutate: (c: ParsedComment) => CommentData): Change[] | null => {
+const replaceBody = (doc: string, id: string, mutate: (c: ParsedComment) => CommentData): Result<Change[], string> => {
 	const c = parseComments(doc).find((x) => x.id === id);
-	if (!c || !c.body) return null;
-	return [{ from: c.body.from, to: c.body.to, insert: serializeBody(id, mutate(c)) }];
+	if (!c) return Result.err("Comment not found.");
+	if (!c.body) return Result.err("Comment has no body to update.");
+	return Result.ok([{ from: c.body.from, to: c.body.to, insert: serializeBody(id, mutate(c)) }]);
 };
 
 const toData = (c: ParsedComment): CommentData => {
@@ -104,9 +117,9 @@ const toggleReactions = (reactions: Reaction[], emoji: string, author: string): 
 	return out.filter((r) => r.authors.length > 0);
 };
 
-export const computeDeleteComment = (doc: string, id: string): Change[] | null => {
+export const computeDeleteComment = (doc: string, id: string): Result<Change[], string> => {
 	const c = parseComments(doc).find((x) => x.id === id);
-	if (!c) return null;
+	if (!c) return Result.err("Comment not found.");
 	const ranges: Change[] = [];
 	if (c.open) ranges.push({ from: c.open.from, to: c.open.to, insert: "" });
 	if (c.close) ranges.push({ from: c.close.from, to: c.close.to, insert: "" });
@@ -115,9 +128,9 @@ export const computeDeleteComment = (doc: string, id: string): Change[] | null =
 		if (from > 0 && doc.charCodeAt(from - 1) === 10) from -= 1;
 		ranges.push({ from, to: c.body.to, insert: "" });
 	}
-	if (ranges.length === 0) return null;
+	if (ranges.length === 0) return Result.err("Nothing to delete.");
 	ranges.sort((a, b) => a.from - b.from);
-	return ranges;
+	return Result.ok(ranges);
 };
 
 /** Apply changes (original coordinates, CM semantics) — used by tests. */

--- a/src/editor/layout.ts
+++ b/src/editor/layout.ts
@@ -13,9 +13,11 @@ const editorLayoutClasses = (state: EditorState): string => {
 	const fv = state.field(commentField, false);
 	const draft = state.field(draftField, false) ?? null;
 	// `dc-has` mirrors the inline column: present only when cards actually render
-	// (comments shown, sidebar not hosting them) or a draft composer is open.
+	// (comments shown, sidebar not hosting them) or a draft composer is open. On
+	// mobile there's no floating column at all, so never reserve its width.
 	const showInline = cfg.showComments() && !cfg.sidebarOpen();
-	const hasColumn = (showInline && !!fv && fv.comments.some((c) => c.body)) || !!draft;
+	const hasColumn =
+		!(cfg.isMobile?.() ?? false) && ((showInline && !!fv && fv.comments.some((c) => c.body)) || !!draft);
 
 	const classes: string[] = [];
 	if (hasColumn) classes.push("dc-has");

--- a/src/editor/margin.ts
+++ b/src/editor/margin.ts
@@ -1,4 +1,5 @@
-import { setIcon } from "obsidian";
+import { Notice, setIcon } from "obsidian";
+import { Result } from "better-result";
 import { EditorView, PluginValue, ViewPlugin } from "@codemirror/view";
 import { ParsedComment } from "../format/types";
 import { anchorRange, isAnchored } from "../format/parse";
@@ -18,6 +19,12 @@ import {
 import { cssEscape } from "../util/css";
 
 const CARD_GAP = 8;
+
+/** Editor-margin writes go through a live CodeMirror view (no I/O), so the only
+ *  failure is a compute error — surface it as a notice rather than swallowing it. */
+const notifyErr = (result: Result<unknown, string>): void => {
+	if (result.isErr()) new Notice(`Couldn't save the comment: ${result.error}`);
+};
 const ORPHAN_TOP = 8;
 
 /**
@@ -65,12 +72,12 @@ class MarginView implements PluginValue {
 			onResize: () => this.reposition(),
 			animateLayout: () => this.animateLayout(),
 			revealComposer: (id) => this.revealComposer(id),
-			reply: (id, text) => void appendReply(view, id, text, this.cb.getAuthor()),
-			setResolved: (id, resolved) => void setResolved(view, id, resolved),
-			remove: (id) => void deleteComment(view, id),
-			editEntry: (id, index, text) => void editEntry(view, id, index, text),
-			deleteEntry: (id, index) => void deleteEntry(view, id, index),
-			toggleReaction: (id, emoji) => void toggleReaction(view, id, emoji, this.cb.getAuthor()),
+			reply: (id, text) => notifyErr(appendReply(view, id, text, this.cb.getAuthor())),
+			setResolved: (id, resolved) => notifyErr(setResolved(view, id, resolved)),
+			remove: (id) => notifyErr(deleteComment(view, id)),
+			editEntry: (id, index, text) => notifyErr(editEntry(view, id, index, text)),
+			deleteEntry: (id, index) => notifyErr(deleteEntry(view, id, index)),
+			toggleReaction: (id, emoji) => notifyErr(toggleReaction(view, id, emoji, this.cb.getAuthor())),
 			openInSidebar: (id) => view.state.facet(commentConfig).openInSidebar?.(id),
 		};
 
@@ -269,7 +276,7 @@ class MarginView implements PluginValue {
 		const submit = () => {
 			const text = textarea.value.trim();
 			const draft = this.view.state.field(draftField, false);
-			if (text && draft) addComment(this.view, draft.from, draft.to, text, this.cb.getAuthor());
+			if (text && draft) notifyErr(addComment(this.view, draft.from, draft.to, text, this.cb.getAuthor()));
 			this.view.dispatch({ effects: clearDraft.of(null) });
 		};
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Editor, MarkdownView, Notice, Platform, Plugin, WorkspaceLeaf, debounce } from "obsidian";
+import { Editor, MarkdownView, Notice, Platform, Plugin, TFile, WorkspaceLeaf, debounce } from "obsidian";
 import { EditorView } from "@codemirror/view";
 import { commentField } from "./editor/state";
 import { marginPlugin } from "./editor/margin";
@@ -203,14 +203,24 @@ export default class DocCommentsPlugin extends Plugin {
 				return;
 			}
 			new CommentModal(this.app, selected, (text) => {
-				void insertCommentInFile(this.app, file, from, to, text, this.authorName()).then(() =>
-					this.scheduleReadingRefresh(),
-				);
+				void this.insertReadingComment(file, from, to, text);
 			}).open();
 			return;
 		}
 		// Same inline draft composer as the editor (no modal).
 		this.readingManager?.startDraft(view, from, to, selection.getRangeAt(0));
+	}
+
+	/** Mobile reading-view create: write to the file (no editor surface) and refresh.
+	 *  Wrapped like every other vault.process call site so a failed write surfaces. */
+	private async insertReadingComment(file: TFile, from: number, to: number, text: string): Promise<void> {
+		try {
+			await insertCommentInFile(this.app, file, from, to, text, this.authorName());
+			this.scheduleReadingRefresh();
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "unknown error";
+			new Notice(`Couldn't add the comment: ${message}`);
+		}
 	}
 
 	private async toggleComments(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,15 @@
-import { Editor, MarkdownView, Notice, Plugin, WorkspaceLeaf, debounce } from "obsidian";
+import { Editor, MarkdownView, Notice, Platform, Plugin, WorkspaceLeaf, debounce } from "obsidian";
 import { EditorView } from "@codemirror/view";
 import { commentField } from "./editor/state";
 import { marginPlugin } from "./editor/margin";
 import { commentConfig } from "./editor/config";
 import { editorLayoutField } from "./editor/layout";
 import { draftField, setDraft } from "./editor/draft";
+import { addComment, insertCommentInFile } from "./editor/commands";
 import { findSectionRange, highlightPostProcessor } from "./reading/highlight";
 import { ReadingDeps, ReadingMarginManager } from "./reading/margin";
 import { COMMENTS_VIEW_TYPE, CommentsSidebarView, SidebarDeps } from "./ui/sidebar";
+import { CommentModal } from "./ui/comment-modal";
 import { DEFAULT_SETTINGS, DocCommentsSettings, DocCommentsSettingTab } from "./settings";
 
 export default class DocCommentsPlugin extends Plugin {
@@ -31,11 +33,15 @@ export default class DocCommentsPlugin extends Plugin {
 				showResolved: () => this.settings.showResolved,
 				sidebarOpen: () => this.sidebarOpen,
 				openInSidebar: (id) => void this.revealComment(id),
+				isMobile: () => Platform.isMobile,
 			}),
 			// Reflects dc-has / dc-highlights / dc-hide-resolved onto .cm-editor so the
 			// stylesheet caps the text column without a :has() selector.
 			editorLayoutField,
-			marginPlugin,
+			// The floating margin column needs horizontal room mobile doesn't have, so
+			// there we skip it entirely — comments live in the sidebar, highlights stay,
+			// and new comments are composed in a modal (see startAddComment).
+			...(Platform.isMobile ? [] : [marginPlugin]),
 		]);
 
 		// Reading view: a separate render path. Highlights come from a post-processor;
@@ -47,6 +53,7 @@ export default class DocCommentsPlugin extends Plugin {
 			showResolved: () => this.settings.showResolved,
 			sidebarOpen: () => this.sidebarOpen,
 			openInSidebar: (id) => void this.revealComment(id),
+			isMobile: () => Platform.isMobile,
 		};
 		this.readingManager = new ReadingMarginManager(readingDeps);
 		this.scheduleReadingRefresh = debounce(() => this.readingManager?.refresh(), 50, true);
@@ -153,6 +160,15 @@ export default class DocCommentsPlugin extends Plugin {
 			new Notice("Select some text to comment on.");
 			return;
 		}
+		if (Platform.isMobile) {
+			// No floating margin composer on mobile — collect the text in a modal,
+			// then write through the same editor path so it's a single undo step.
+			const quote = view.state.doc.sliceString(from, to);
+			new CommentModal(this.app, quote, (text) => {
+				addComment(view, from, to, text, this.authorName());
+			}).open();
+			return;
+		}
 		// Show a draft composer card in the margin (Notion-style) instead of a modal.
 		view.dispatch({ effects: setDraft.of({ from, to }) });
 	}
@@ -177,8 +193,24 @@ export default class DocCommentsPlugin extends Plugin {
 			return;
 		}
 		const from = section.from + idx;
+		const to = from + selected.length;
+		if (Platform.isMobile) {
+			// No margin composer on mobile — write straight to the file from a modal,
+			// then refresh so the new highlight appears in the reading view.
+			const file = view.file;
+			if (!file) {
+				new Notice("No file is open.");
+				return;
+			}
+			new CommentModal(this.app, selected, (text) => {
+				void insertCommentInFile(this.app, file, from, to, text, this.authorName()).then(() =>
+					this.scheduleReadingRefresh(),
+				);
+			}).open();
+			return;
+		}
 		// Same inline draft composer as the editor (no modal).
-		this.readingManager?.startDraft(view, from, from + selected.length, selection.getRangeAt(0));
+		this.readingManager?.startDraft(view, from, to, selection.getRangeAt(0));
 	}
 
 	private async toggleComments(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { Editor, MarkdownView, Notice, Platform, Plugin, TFile, WorkspaceLeaf, debounce } from "obsidian";
+import { Result } from "better-result";
 import { EditorView } from "@codemirror/view";
 import { commentField } from "./editor/state";
 import { marginPlugin } from "./editor/margin";
@@ -165,7 +166,8 @@ export default class DocCommentsPlugin extends Plugin {
 			// then write through the same editor path so it's a single undo step.
 			const quote = view.state.doc.sliceString(from, to);
 			new CommentModal(this.app, quote, (text) => {
-				addComment(view, from, to, text, this.authorName());
+				const result = addComment(view, from, to, text, this.authorName());
+				if (result.isErr()) new Notice(`Couldn't add the comment: ${result.error}`);
 			}).open();
 			return;
 		}
@@ -212,15 +214,12 @@ export default class DocCommentsPlugin extends Plugin {
 	}
 
 	/** Mobile reading-view create: write to the file (no editor surface) and refresh.
-	 *  Wrapped like every other vault.process call site so a failed write surfaces. */
+	 *  insertCommentInFile already folds I/O + compute failures into the Result. */
 	private async insertReadingComment(file: TFile, from: number, to: number, text: string): Promise<void> {
-		try {
-			await insertCommentInFile(this.app, file, from, to, text, this.authorName());
-			this.scheduleReadingRefresh();
-		} catch (error) {
-			const message = error instanceof Error ? error.message : "unknown error";
-			new Notice(`Couldn't add the comment: ${message}`);
-		}
+		(await insertCommentInFile(this.app, file, from, to, text, this.authorName())).match({
+			ok: () => this.scheduleReadingRefresh(),
+			err: (message) => new Notice(`Couldn't add the comment: ${message}`),
+		});
 	}
 
 	private async toggleComments(): Promise<void> {
@@ -259,19 +258,20 @@ export default class DocCommentsPlugin extends Plugin {
 	/** Reveal the comments sidebar panel, creating it in the right split if needed. */
 	private async activateSidebar(): Promise<void> {
 		const { workspace } = this.app;
-		try {
-			let leaf: WorkspaceLeaf | null = workspace.getLeavesOfType(COMMENTS_VIEW_TYPE)[0] ?? null;
-			if (!leaf) {
-				leaf = workspace.getRightLeaf(false);
-				if (!leaf) return;
-				await leaf.setViewState({ type: COMMENTS_VIEW_TYPE, active: true });
-			}
-			await workspace.revealLeaf(leaf);
-			this.syncSidebarOpen();
-		} catch (error) {
-			const message = error instanceof Error ? error.message : "unknown error";
-			new Notice(`Couldn't open the comments sidebar: ${message}`);
-		}
+		const opened = await Result.tryPromise({
+			try: async () => {
+				let leaf: WorkspaceLeaf | null = workspace.getLeavesOfType(COMMENTS_VIEW_TYPE)[0] ?? null;
+				if (!leaf) {
+					leaf = workspace.getRightLeaf(false);
+					if (!leaf) return;
+					await leaf.setViewState({ type: COMMENTS_VIEW_TYPE, active: true });
+				}
+				await workspace.revealLeaf(leaf);
+				this.syncSidebarOpen();
+			},
+			catch: (e) => (e instanceof Error ? e.message : "unknown error"),
+		});
+		if (opened.isErr()) new Notice(`Couldn't open the comments sidebar: ${opened.error}`);
 	}
 
 	/** Open the sidebar and scroll it to a thread — the escape from a margin card too

--- a/src/reading/margin.ts
+++ b/src/reading/margin.ts
@@ -1,4 +1,5 @@
 import { App, MarkdownView, Notice, setIcon } from "obsidian";
+import { Result } from "better-result";
 import { ParsedComment } from "../format/types";
 import { existingIds, parseComments } from "../format/parse";
 import { generateId } from "../format/ids";
@@ -104,19 +105,27 @@ class ReadingMargin {
 		this.position();
 	}
 
-	private async edit(compute: (doc: string) => Change[] | null): Promise<void> {
+	private async edit(compute: (doc: string) => Result<Change[], string>): Promise<void> {
 		const file = this.view.file;
 		if (!file) return;
-		try {
-			const newData = await this.deps.app.vault.process(file, (data) => {
-				const changes = compute(data);
-				return changes ? applyChanges(data, changes) : data;
-			});
-			await this.refresh(newData);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : "unknown error";
-			new Notice(`Couldn't save the comment: ${message}`);
-		}
+		let computeError: string | undefined;
+		const io = await Result.tryPromise({
+			try: () =>
+				this.deps.app.vault.process(file, (data) => {
+					const result = compute(data);
+					if (result.isErr()) {
+						computeError = result.error;
+						return data;
+					}
+					return applyChanges(data, result.value);
+				}),
+			catch: (e) => (e instanceof Error ? e.message : "unknown error"),
+		});
+		const outcome: Result<string, string> = computeError ? Result.err(computeError) : io;
+		outcome.match({
+			ok: (newData) => void this.refresh(newData),
+			err: (message) => new Notice(`Couldn't save the comment: ${message}`),
+		});
 	}
 
 	private reconcileCards(): void {
@@ -252,22 +261,30 @@ class ReadingMargin {
 	private async insertComment(from: number, to: number, text: string): Promise<void> {
 		const file = this.view.file;
 		if (!file) return;
-		try {
-			const newData = await this.deps.app.vault.process(file, (data) => {
-				const id = generateId(existingIds(data));
-				const changes = computeAddComment(data, from, to, {
-					id,
-					createdAt: new Date().toISOString(),
-					author: this.deps.getAuthor(),
-					text,
-				});
-				return changes ? applyChanges(data, changes) : data;
-			});
-			await this.refresh(newData);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : "unknown error";
-			new Notice(`Couldn't add the comment: ${message}`);
-		}
+		let computeError: string | undefined;
+		const io = await Result.tryPromise({
+			try: () =>
+				this.deps.app.vault.process(file, (data) => {
+					const id = generateId(existingIds(data));
+					const result = computeAddComment(data, from, to, {
+						id,
+						createdAt: new Date().toISOString(),
+						author: this.deps.getAuthor(),
+						text,
+					});
+					if (result.isErr()) {
+						computeError = result.error;
+						return data;
+					}
+					return applyChanges(data, result.value);
+				}),
+			catch: (e) => (e instanceof Error ? e.message : "unknown error"),
+		});
+		const outcome: Result<string, string> = computeError ? Result.err(computeError) : io;
+		outcome.match({
+			ok: (newData) => void this.refresh(newData),
+			err: (message) => new Notice(`Couldn't add the comment: ${message}`),
+		});
 	}
 
 	private clearDraft(): void {

--- a/src/reading/margin.ts
+++ b/src/reading/margin.ts
@@ -27,6 +27,8 @@ export type ReadingDeps = {
 	sidebarOpen: () => boolean;
 	/** Reveal a thread in the sidebar — used by a margin card too tall to fit. */
 	openInSidebar?: (id: string) => void;
+	/** True on Obsidian mobile — no floating column; just drive highlight visibility. */
+	isMobile?: () => boolean;
 };
 
 /** A margin column for one reading-view container, aligned to highlight spans. */
@@ -390,6 +392,7 @@ export class ReadingMarginManager {
 	constructor(private deps: ReadingDeps) {}
 
 	refresh(): void {
+		const mobile = this.deps.isMobile?.() ?? false;
 		const active = new Set<HTMLElement>();
 		for (const leaf of this.deps.app.workspace.getLeavesOfType("markdown")) {
 			const view = leaf.view;
@@ -397,6 +400,15 @@ export class ReadingMarginManager {
 			const rv = view.containerEl.querySelector(".markdown-reading-view");
 			if (!(rv instanceof HTMLElement)) continue;
 			active.add(rv);
+			if (mobile) {
+				// Mobile: no floating cards or reserved column. Just keep the in-text
+				// highlights' visibility in sync with the toggles (no `dc-has`, so the
+				// text keeps full width). Comments are read/created via the sidebar.
+				rv.toggleClass("dc-highlights", this.deps.showComments());
+				rv.toggleClass("dc-hide-resolved", !this.deps.showResolved());
+				rv.removeClass("dc-has");
+				continue;
+			}
 			let margin = this.margins.get(rv);
 			if (!margin) {
 				margin = new ReadingMargin(rv, view, this.deps);

--- a/src/ui/comment-modal.ts
+++ b/src/ui/comment-modal.ts
@@ -1,0 +1,63 @@
+import { App, Modal, Setting } from "obsidian";
+
+/**
+ * A plain text-entry dialog for composing a new comment. Used where the inline
+ * margin composer isn't available — i.e. on mobile, which has no floating column.
+ * The caller supplies the quoted text (shown for context) and receives the entered
+ * comment via `onSubmit`; the modal handles its own open/close.
+ */
+export class CommentModal extends Modal {
+	private value = "";
+
+	constructor(
+		app: App,
+		private quote: string,
+		private onSubmit: (text: string) => void,
+	) {
+		super(app);
+	}
+
+	onOpen(): void {
+		const { contentEl, titleEl } = this;
+		titleEl.setText("Add comment");
+
+		const quote = this.quote.trim();
+		if (quote) contentEl.createDiv({ cls: "dc-modal-quote", text: quote });
+
+		const input = contentEl.createEl("textarea", {
+			cls: "dc-modal-input",
+			attr: { rows: "4", placeholder: "Write a comment…" },
+		});
+		input.addEventListener("input", () => {
+			this.value = input.value;
+		});
+		// Cmd/Ctrl+Enter submits; plain Enter inserts a newline (room to type freely
+		// on a small keyboard).
+		input.addEventListener("keydown", (e) => {
+			if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+				e.preventDefault();
+				this.submit();
+			}
+		});
+		window.setTimeout(() => input.focus(), 0);
+
+		new Setting(contentEl)
+			.addButton((b) => b.setButtonText("Cancel").onClick(() => this.close()))
+			.addButton((b) =>
+				b
+					.setButtonText("Comment")
+					.setCta()
+					.onClick(() => this.submit()),
+			);
+	}
+
+	private submit(): void {
+		const text = this.value.trim();
+		this.close();
+		if (text) this.onSubmit(text);
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+}

--- a/src/ui/sidebar.ts
+++ b/src/ui/sidebar.ts
@@ -1,4 +1,5 @@
 import { App, Debouncer, ItemView, MarkdownView, Notice, TFile, WorkspaceLeaf, debounce } from "obsidian";
+import { Result } from "better-result";
 import { EditorView } from "@codemirror/view";
 import { ParsedComment } from "../format/types";
 import { anchorRange, parseComments } from "../format/parse";
@@ -255,26 +256,38 @@ export class CommentsSidebarView extends ItemView {
 	/** Apply a computed change set to the active note. Prefer the open editor
 	 *  (keeps edits in its undo history and in sync with unsaved changes);
 	 *  fall back to a direct file write for notes only shown in reading view. */
-	private async edit(compute: (doc: string) => Change[] | null): Promise<void> {
+	private async edit(compute: (doc: string) => Result<Change[], string>): Promise<void> {
 		const file = this.file;
 		if (!file) return;
 		const cm = this.editorViewForFile(file);
 		if (cm) {
-			const changes = compute(cm.state.doc.toString());
-			if (changes) cm.dispatch({ changes });
-			await this.refresh();
+			compute(cm.state.doc.toString()).match({
+				ok: (changes) => {
+					cm.dispatch({ changes });
+					void this.refresh();
+				},
+				err: (message) => new Notice(`Couldn't save the comment: ${message}`),
+			});
 			return;
 		}
-		try {
-			const newData = await this.app.vault.process(file, (data) => {
-				const changes = compute(data);
-				return changes ? applyChanges(data, changes) : data;
-			});
-			await this.refresh(newData);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : "unknown error";
-			new Notice(`Couldn't save the comment: ${message}`);
-		}
+		let computeError: string | undefined;
+		const io = await Result.tryPromise({
+			try: () =>
+				this.app.vault.process(file, (data) => {
+					const result = compute(data);
+					if (result.isErr()) {
+						computeError = result.error;
+						return data;
+					}
+					return applyChanges(data, result.value);
+				}),
+			catch: (e) => (e instanceof Error ? e.message : "unknown error"),
+		});
+		const outcome: Result<string, string> = computeError ? Result.err(computeError) : io;
+		outcome.match({
+			ok: (newData) => void this.refresh(newData),
+			err: (message) => new Notice(`Couldn't save the comment: ${message}`),
+		});
 	}
 
 	// ── Document interplay ─────────────────────────────────────────────────

--- a/styles.css
+++ b/styles.css
@@ -543,3 +543,22 @@ body {
 	display: none;
 }
 
+/* ── Mobile "Add comment" modal ────────────────────────────────────────────
+   Used where there's no floating margin composer (mobile). */
+.dc-modal-quote {
+	margin-bottom: 10px;
+	padding: 6px 10px;
+	border-left: 2px solid var(--dc-highlight-border);
+	border-radius: 4px;
+	background-color: var(--background-secondary);
+	color: var(--text-muted);
+	font-size: var(--font-ui-small);
+	max-height: 6em;
+	overflow-y: auto;
+}
+.dc-modal-input {
+	width: 100%;
+	min-height: 5em;
+	resize: vertical;
+}
+

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -27,9 +27,10 @@ describe("insertCommentInFile", () => {
 			(s) => (doc = s),
 		);
 
-		const id = await insertCommentInFile(app, {} as TFile, from, to, "Thursday?", "kyle");
+		const result = await insertCommentInFile(app, {} as TFile, from, to, "Thursday?", "kyle");
 
-		expect(id).toBeTruthy();
+		expect(result.isOk()).toBe(true);
+		const id = result.unwrap();
 		const comments = parseComments(doc);
 		expect(comments).toHaveLength(1);
 		expect(comments[0]!.id).toBe(id);
@@ -38,16 +39,16 @@ describe("insertCommentInFile", () => {
 		expect(comments[0]!.thread[0]!.author).toBe("kyle");
 	});
 
-	it("returns null and writes nothing for an empty range", async () => {
+	it("errs and writes nothing for an empty range", async () => {
 		let doc = "unchanged text";
 		const app = fakeApp(
 			() => doc,
 			(s) => (doc = s),
 		);
 
-		const id = await insertCommentInFile(app, {} as TFile, 3, 3, "ignored", "kyle");
+		const result = await insertCommentInFile(app, {} as TFile, 3, 3, "ignored", "kyle");
 
-		expect(id).toBeNull();
+		expect(result.isErr()).toBe(true);
 		expect(doc).toBe("unchanged text");
 	});
 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -51,4 +51,25 @@ describe("insertCommentInFile", () => {
 		expect(result.isErr()).toBe(true);
 		expect(doc).toBe("unchanged text");
 	});
+
+	it("errs with the I/O reason even after the mutator ran (I/O error wins over the provisional ok)", async () => {
+		const doc = "We should ship on Friday.\n";
+		const from = doc.indexOf("ship on Friday");
+		const to = from + "ship on Friday".length;
+		const app = {
+			vault: {
+				// Run the mutator (so the compute sets a provisional ok(id)) and THEN fail
+				// the write — the folded Result must surface the I/O error, not the stale ok.
+				process: async (_file: TFile, fn: (data: string) => string) => {
+					fn(doc);
+					throw new Error("disk full");
+				},
+			},
+		} as unknown as App;
+
+		const result = await insertCommentInFile(app, {} as TFile, from, to, "hi", "kyle");
+
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) expect(result.error).toBe("disk full");
+	});
 });

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import type { App, TFile } from "obsidian";
+import { insertCommentInFile } from "../src/editor/commands";
+import { parseComments } from "../src/format/parse";
+
+// A minimal `app.vault.process` stub: run the mutator over an in-memory string and
+// keep the result. Mirrors how Obsidian applies the transform and returns the text.
+function fakeApp(getDoc: () => string, setDoc: (s: string) => void): App {
+	return {
+		vault: {
+			process: async (_file: TFile, fn: (data: string) => string) => {
+				const next = fn(getDoc());
+				setDoc(next);
+				return next;
+			},
+		},
+	} as unknown as App;
+}
+
+describe("insertCommentInFile", () => {
+	it("writes a new comment to the file and returns its id", async () => {
+		let doc = "We should ship on Friday regardless.\n";
+		const from = doc.indexOf("ship on Friday");
+		const to = from + "ship on Friday".length;
+		const app = fakeApp(
+			() => doc,
+			(s) => (doc = s),
+		);
+
+		const id = await insertCommentInFile(app, {} as TFile, from, to, "Thursday?", "kyle");
+
+		expect(id).toBeTruthy();
+		const comments = parseComments(doc);
+		expect(comments).toHaveLength(1);
+		expect(comments[0]!.id).toBe(id);
+		expect(comments[0]!.quote).toBe("ship on Friday");
+		expect(comments[0]!.thread[0]!.text).toBe("Thursday?");
+		expect(comments[0]!.thread[0]!.author).toBe("kyle");
+	});
+
+	it("returns null and writes nothing for an empty range", async () => {
+		let doc = "unchanged text";
+		const app = fakeApp(
+			() => doc,
+			(s) => (doc = s),
+		);
+
+		const id = await insertCommentInFile(app, {} as TFile, 3, 3, "ignored", "kyle");
+
+		expect(id).toBeNull();
+		expect(doc).toBe("unchanged text");
+	});
+});

--- a/test/edits.test.ts
+++ b/test/edits.test.ts
@@ -20,7 +20,7 @@ function add(): string {
 		createdAt: "2026-06-17T10:00:00.000Z",
 		author: "kyle",
 		text: "I thought we agreed Thursday?",
-	})!;
+	}).unwrap();
 	return applyChanges(DOC, changes);
 }
 
@@ -45,8 +45,9 @@ describe("computeAddComment", () => {
 		expect(stripComments(out)).toContain("We should ship on Friday regardless of the QA timeline.");
 	});
 
-	it("returns null for an empty selection", () => {
-		expect(computeAddComment(DOC, FROM, FROM, { id: "x", createdAt: "t", author: "a", text: "b" })).toBeNull();
+	it("errs for an empty selection", () => {
+		const result = computeAddComment(DOC, FROM, FROM, { id: "x", createdAt: "t", author: "a", text: "b" });
+		expect(result.isErr()).toBe(true);
 	});
 });
 
@@ -58,7 +59,7 @@ describe("reply / resolve", () => {
 				createdAt: "2026-06-17T11:00:00.000Z",
 				author: "sam",
 				text: "Thursday is better",
-			})!,
+			}).unwrap(),
 		);
 		const c = parseComments(out)[0];
 		expect(c.thread).toHaveLength(2);
@@ -66,17 +67,21 @@ describe("reply / resolve", () => {
 	});
 
 	it("toggles resolved status", () => {
-		const resolved = applyChanges(add(), computeSetResolved(add(), "k3f9", true)!);
+		const resolved = applyChanges(add(), computeSetResolved(add(), "k3f9", true).unwrap());
 		expect(parseComments(resolved)[0].status).toBe("resolved");
-		const reopened = applyChanges(resolved, computeSetResolved(resolved, "k3f9", false)!);
+		const reopened = applyChanges(resolved, computeSetResolved(resolved, "k3f9", false).unwrap());
 		expect(parseComments(reopened)[0].status).toBe("open");
+	});
+
+	it("errs when the comment id is unknown", () => {
+		expect(computeSetResolved(add(), "nope", true).isErr()).toBe(true);
 	});
 });
 
 describe("computeDeleteComment", () => {
 	it("round-trips back to the original document", () => {
 		const out = add();
-		const restored = applyChanges(out, computeDeleteComment(out, "k3f9")!);
+		const restored = applyChanges(out, computeDeleteComment(out, "k3f9").unwrap());
 		expect(restored).toBe(DOC);
 	});
 });

--- a/test/reactions.test.ts
+++ b/test/reactions.test.ts
@@ -41,7 +41,7 @@ describe("entry + reaction edits", () => {
 	const base = wrap("r1", serializeBody("r1", { ...DATA, reactions: [] }));
 
 	it("edits an entry's text without touching others", () => {
-		const out = applyChanges(base, computeEditEntry(base, "r1", 1, "second edited")!);
+		const out = applyChanges(base, computeEditEntry(base, "r1", 1, "second edited").unwrap());
 		const c = parseComments(out)[0];
 		expect(c.thread).toHaveLength(2);
 		expect(c.thread[0].text).toBe("first");
@@ -49,21 +49,21 @@ describe("entry + reaction edits", () => {
 	});
 
 	it("deletes a reply by index", () => {
-		const c = parseComments(applyChanges(base, computeDeleteEntry(base, "r1", 1)!))[0];
+		const c = parseComments(applyChanges(base, computeDeleteEntry(base, "r1", 1).unwrap()))[0];
 		expect(c.thread).toHaveLength(1);
 		expect(c.thread[0].text).toBe("first");
 	});
 
 	it("toggles a reaction on and off", () => {
-		const on = applyChanges(base, computeToggleReaction(base, "r1", "👍", "kyle")!);
+		const on = applyChanges(base, computeToggleReaction(base, "r1", "👍", "kyle").unwrap());
 		expect(parseComments(on)[0].reactions).toEqual([{ emoji: "👍", authors: ["kyle"] }]);
-		const off = applyChanges(on, computeToggleReaction(on, "r1", "👍", "kyle")!);
+		const off = applyChanges(on, computeToggleReaction(on, "r1", "👍", "kyle").unwrap());
 		expect(parseComments(off)[0].reactions).toEqual([]);
 	});
 
 	it("adds a second author to an existing reaction", () => {
-		const a = applyChanges(base, computeToggleReaction(base, "r1", "❤️", "kyle")!);
-		const b = applyChanges(a, computeToggleReaction(a, "r1", "❤️", "sam")!);
+		const a = applyChanges(base, computeToggleReaction(base, "r1", "❤️", "kyle").unwrap());
+		const b = applyChanges(a, computeToggleReaction(a, "r1", "❤️", "sam").unwrap());
 		expect(parseComments(b)[0].reactions).toEqual([{ emoji: "❤️", authors: ["kyle", "sam"] }]);
 	});
 });


### PR DESCRIPTION
Two related changes, bundled together.

## 1. Mobile support
Obsidian mobile has no horizontal room for the floating margin column, so on mobile:
- The editor `marginPlugin` isn't registered and the reading-view manager runs a **highlights-only** path — no cards, no reserved text column (prose stays full-width).
- The in-text **highlights** and the **"All discussions" sidebar** still work; the sidebar becomes the surface for read / reply / resolve / edit / delete.
- New comments are composed in a small **modal** (`CommentModal`) instead of the margin draft composer — `addComment` in edit mode, `insertCommentInFile` in reading mode.

All mobile behavior is gated behind `Platform.isMobile` (threaded via the editor config facet + reading deps, so the test-graph modules avoid a runtime `obsidian` import), leaving the desktop margin/composer flow unchanged.

`manifest.json` → `isDesktopOnly: false`; README updated to drop the desktop-only stipulation.

✅ Verified working on a physical device (via Obsidian Sync).

## 2. `better-result` for predictable error handling
Replaces the `Change[] | null` / `boolean` / `try-catch` failure signalling in the comment write/edit/create path with `Result<T, string>` (the [`better-result`](https://better-result.dev) library), so failures are explicit values that carry the reason end-to-end:
- `edits.ts` `compute*` → `Result<Change[], string>` (the Err carries the reason: empty range / comment not found / no body / nothing to delete).
- `commands.ts` writes → `Result`; `insertCommentInFile` folds **I/O failure + compute failure into one `Result`** via `Result.tryPromise`.
- Call sites (reading margin, sidebar, editor margin, `main.ts`) `.match` / `isErr()` and surface the reason in a `Notice` — several were previously **swallowed** (e.g. the editor-margin reply/resolve/react/delete callbacks).

Out of scope (left as `try/catch`): defensive DOM-feasibility guards (`range.surroundContents`) and best-effort reads (keep-last-render) — Result adds no clarity there.

`better-result` is added as a bundled `dependency` (ESM, inlined into `main.js` by esbuild).

## Validation
- `npm run check` (oxfmt, oxlint + obsidianmd eslint, tsc) and `npm run build` green; **40 tests** — added coverage for the new Err paths, including `insertCommentInFile`'s I/O-failure branch.
- Independently reviewed across three passes; no blocking or should-fix items outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)