### PR TITLE
Fix jarring document reflow when adding a comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to **Document Comments**. The release workflow uses the section
 matching the pushed tag as that GitHub release's notes, so add an entry here before tagging.
 
+## 0.1.5
+- Fixed the document reflowing (shifting left, then re-centering) every time you started or finished a comment. The new-comment composer is a floating overlay and no longer reserves the margin column, so the text stays put — most noticeable when the comments sidebar is open and the inline column isn't shown ([#15](https://github.com/kylemcd/obsidian-document-comments/issues/15)).
+
 ## 0.1.4
 - **Mobile support** — Document Comments now works on Obsidian mobile. There's no floating margin on phones and tablets; instead the in-text highlights mark commented text and you read, reply, and resolve through the **"All discussions" sidebar**, with new comments composed in a quick dialog. It's the same inline storage, so a note's comments are identical across desktop and mobile.
 - Saving a comment now reports a clear reason if it ever fails, instead of occasionally failing silently.

--- a/src/editor/layout.ts
+++ b/src/editor/layout.ts
@@ -1,7 +1,6 @@
 import { EditorState, StateField } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { commentField } from "./state";
-import { draftField } from "./draft";
 import { commentConfig } from "./config";
 
 // Defined ABOVE editorLayoutField: StateField.define evaluates `provide` EAGERLY
@@ -11,13 +10,15 @@ import { commentConfig } from "./config";
 const editorLayoutClasses = (state: EditorState): string => {
 	const cfg = state.facet(commentConfig);
 	const fv = state.field(commentField, false);
-	const draft = state.field(draftField, false) ?? null;
-	// `dc-has` mirrors the inline column: present only when cards actually render
-	// (comments shown, sidebar not hosting them) or a draft composer is open. On
-	// mobile there's no floating column at all, so never reserve its width.
-	const showInline = cfg.showComments() && !cfg.sidebarOpen();
-	const hasColumn =
-		!(cfg.isMobile?.() ?? false) && ((showInline && !!fv && fv.comments.some((c) => c.body)) || !!draft);
+	// `dc-has` mirrors the inline column: present only when persistent cards
+	// actually render (comments shown, sidebar not hosting them, not mobile). It is
+	// deliberately NOT tied to the transient draft composer — reserving the column
+	// for a draft toggled the sizer's width cap on when a composer opened and off
+	// when it closed, reflowing (and re-centering) the whole document on every new
+	// comment (issue #15). The composer is a floating overlay, so with no cap it just
+	// sits over the right-hand whitespace; the text only shifts once a card persists.
+	const showInline = cfg.showComments() && !cfg.sidebarOpen() && !(cfg.isMobile?.() ?? false);
+	const hasColumn = showInline && !!fv && fv.comments.some((c) => c.body);
 
 	const classes: string[] = [];
 	if (hasColumn) classes.push("dc-has");

--- a/src/reading/margin.ts
+++ b/src/reading/margin.ts
@@ -156,7 +156,18 @@ class ReadingMargin {
 		// State classes live on the reading-view container (Obsidian-owned, safe to
 		// write directly), so the stylesheet caps the text column with plain
 		// descendant selectors instead of :has().
-		this.readingView.toggleClass("dc-has", this.comments.length > 0 || !!this.draft);
+		//
+		// `dc-has` reserves the column (caps the sizer) and is tied ONLY to persistent
+		// cards — never the transient draft composer. Reserving it for a draft reflowed
+		// (and re-centered) the whole preview every time you opened/closed the composer
+		// (issue #15). `dc-margin` is the lighter "the floating column is present"
+		// signal: it just makes the container `position: relative` so the absolutely
+		// positioned composer has a containing block (unlike the editor, CodeMirror
+		// doesn't force position on the reading-view element). The composer then floats
+		// over the right gutter without shifting the text.
+		const hasCards = this.comments.length > 0;
+		this.readingView.toggleClass("dc-has", hasCards);
+		this.readingView.toggleClass("dc-margin", hasCards || !!this.draft);
 		// Highlights follow the master toggle alone, so they persist while the
 		// sidebar panel hosts the cards (dc-has is off, dc-highlights stays on).
 		this.readingView.toggleClass("dc-highlights", this.deps.showComments());
@@ -301,6 +312,10 @@ class ReadingMargin {
 		this.draftEl?.remove();
 		this.draftEl = null;
 		this.draft = null;
+		// Re-run layout so the composer's `dc-margin` (and its reserved slot in the
+		// stack) is dropped immediately on cancel — the editor margin gets this for
+		// free via its dispatch cycle; the reading margin has to ask for it.
+		this.position();
 	}
 
 	private setActive(id: string | null): void {
@@ -394,7 +409,7 @@ class ReadingMargin {
 		this.readingView.removeEventListener("mousedown", this.onMouseDown);
 		// The container we own goes away; the state classes sit on Obsidian's
 		// reading-view element, so clear them explicitly to avoid leaving it capped.
-		this.readingView.removeClasses(["dc-has", "dc-highlights", "dc-hide-resolved"]);
+		this.readingView.removeClasses(["dc-has", "dc-margin", "dc-highlights", "dc-hide-resolved"]);
 		for (const card of this.cards.values()) card.destroy();
 		this.container.remove();
 		this.cards.clear();
@@ -423,7 +438,7 @@ export class ReadingMarginManager {
 				// text keeps full width). Comments are read/created via the sidebar.
 				rv.toggleClass("dc-highlights", this.deps.showComments());
 				rv.toggleClass("dc-hide-resolved", !this.deps.showResolved());
-				rv.removeClass("dc-has");
+				rv.removeClasses(["dc-has", "dc-margin"]);
 				continue;
 			}
 			let margin = this.margins.get(rv);

--- a/styles.css
+++ b/styles.css
@@ -36,7 +36,12 @@ body {
 /* Same treatment for the reading view (separate render path, same math). The extra
    `.markdown-preview-view` step out-specifies core's three-class readable-line rule
    (.markdown-preview-view.is-readable-line-width .markdown-preview-sizer). */
-.markdown-reading-view.dc-has {
+/* `dc-margin` (present whenever the floating column renders, including a lone draft
+   composer) establishes the containing block for the absolutely positioned margin.
+   Kept separate from `dc-has` (the sizer cap) so opening a draft doesn't reflow the
+   text — see issue #15. The editor doesn't need this: CodeMirror already forces
+   `.cm-editor` to position: relative. */
+.markdown-reading-view.dc-margin {
 	position: relative;
 }
 .markdown-reading-view.dc-has .markdown-preview-view .markdown-preview-sizer {

--- a/test/editor-view.test.ts
+++ b/test/editor-view.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, test } from "vitest";
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { commentField } from "../src/editor/state";
-import { draftField } from "../src/editor/draft";
+import { draftField, setDraft } from "../src/editor/draft";
 import { commentConfig } from "../src/editor/config";
 import { editorLayoutField } from "../src/editor/layout";
 
@@ -89,5 +89,27 @@ describe("editor extensions open every note without crashing", () => {
 		);
 		expect(withComment).toContain("dc-has"); // a comment reserves the column
 		expect(withComment).toContain("dc-highlights");
+	});
+
+	// Regression for issue #15: opening the transient "new comment" composer must
+	// NOT reserve the column. It used to toggle `dc-has`, which caps the sizer
+	// width and reflows/re-centers the whole document every time you start (and
+	// finish) a comment. The floating composer overlays the gutter instead.
+	test("an open draft does not reserve the column (no reflow)", () => {
+		const parent = document.createElement("div");
+		document.body.appendChild(parent);
+		const view = new EditorView({
+			state: EditorState.create({
+				doc: "Just plain text.\nNo comments here.\n",
+				extensions: [commentField, draftField, config, editorLayoutField],
+			}),
+			parent,
+		});
+		view.dispatch({ effects: setDraft.of({ from: 0, to: 4 }) });
+		view.requestMeasure();
+		const className = view.dom.className;
+		view.destroy();
+		expect(className).not.toContain("dc-has"); // draft is a floating overlay, no column reserved
+		expect(className).toContain("dc-highlights"); // highlights still follow the master toggle
 	});
 });


### PR DESCRIPTION
Closes #15.

## Problem
When adding a comment, the new-comment composer appears in the right margin and the **whole document reflows left**; creating or cancelling the comment shifts the text back to centered. It's jarring — most noticeable when the comments sidebar is open and the inline column isn't shown, so nothing else is holding the layout in place.

## Root cause
Layout reserves the ~320px margin column by capping the text container's width via a `dc-has` class (`.cm-sizer` in the editor, `.markdown-preview-sizer` in reading view). That class was toggled **on** for the transient draft composer and **off** again when it closed — so every comment you started or finished reflowed and re-centered the document.

## Fix
The composer is a floating overlay, so it never needed the reserved column. `dc-has` is now tied to **persistent cards only**, in both surfaces:
- **Editor** (`src/editor/layout.ts`): dropped `|| !!draft` from `hasColumn`.
- **Reading view** (`src/reading/margin.ts` + `styles.css`): `dc-has` (sizer cap) is persistent-cards-only. Because `.markdown-reading-view` — unlike CodeMirror's `.cm-editor` — isn't inherently `position: relative`, a lighter `dc-margin` class now carries the composer's containing block without capping the sizer. `clearDraft()` re-runs layout so the class and card stack clear immediately on cancel.

The composer now floats over the right-hand gutter and the text stays put. It shifts only once — when a comment actually persists and its card renders (expected, and it doesn't happen at all in the sidebar-open workflow from the report).

## Testing
- Added a regression test asserting an open draft does **not** add `dc-has` (`test/editor-view.test.ts`).
- `npm run check` passes: format, lint, typecheck, 41/41 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)