### PR TITLE
Fix inline comment column reserving space when all comments resolved

### DIFF
--- a/src/editor/layout.ts
+++ b/src/editor/layout.ts
@@ -18,7 +18,12 @@ const editorLayoutClasses = (state: EditorState): string => {
 	// comment (issue #15). The composer is a floating overlay, so with no cap it just
 	// sits over the right-hand whitespace; the text only shifts once a card persists.
 	const showInline = cfg.showComments() && !cfg.sidebarOpen() && !(cfg.isMobile?.() ?? false);
-	const hasColumn = showInline && !!fv && fv.comments.some((c) => c.body);
+	// Only comments whose card actually renders reserve the column. A resolved
+	// comment's card is `display:none` while resolved are hidden (dc-hide-resolved),
+	// so counting it kept the column — and its reserved width — around with nothing
+	// in it once every comment was resolved (issue #30). Mirror that visibility here.
+	const cardVisible = (status: string): boolean => cfg.showResolved() || status !== "resolved";
+	const hasColumn = showInline && !!fv && fv.comments.some((c) => c.body && cardVisible(c.status));
 
 	const classes: string[] = [];
 	if (hasColumn) classes.push("dc-has");

--- a/src/editor/layout.ts
+++ b/src/editor/layout.ts
@@ -22,8 +22,9 @@ const editorLayoutClasses = (state: EditorState): string => {
 	// comment's card is `display:none` while resolved are hidden (dc-hide-resolved),
 	// so counting it kept the column — and its reserved width — around with nothing
 	// in it once every comment was resolved (issue #30). Mirror that visibility here.
-	const cardVisible = (status: string): boolean => cfg.showResolved() || status !== "resolved";
-	const hasColumn = showInline && !!fv && fv.comments.some((c) => c.body && cardVisible(c.status));
+	// The reading-view margin applies the same guard (src/reading/margin.ts).
+	const hasColumn =
+		showInline && !!fv && fv.comments.some((c) => c.body && (cfg.showResolved() || c.status !== "resolved"));
 
 	const classes: string[] = [];
 	if (hasColumn) classes.push("dc-has");

--- a/src/reading/margin.ts
+++ b/src/reading/margin.ts
@@ -165,7 +165,11 @@ class ReadingMargin {
 		// positioned composer has a containing block (unlike the editor, CodeMirror
 		// doesn't force position on the reading-view element). The composer then floats
 		// over the right gutter without shifting the text.
-		const hasCards = this.comments.length > 0;
+		// Only a comment whose card actually renders reserves the column. A resolved
+		// comment's card is `display:none` while resolved are hidden (dc-hide-resolved),
+		// so counting it kept the empty column around once every comment was resolved
+		// (issue #30) — mirror that visibility, exactly as the editor layout does.
+		const hasCards = this.comments.some((c) => this.deps.showResolved() || c.status !== "resolved");
 		this.readingView.toggleClass("dc-has", hasCards);
 		this.readingView.toggleClass("dc-margin", hasCards || !!this.draft);
 		// Highlights follow the master toggle alone, so they persist while the

--- a/test/editor-view.test.ts
+++ b/test/editor-view.test.ts
@@ -91,6 +91,40 @@ describe("editor extensions open every note without crashing", () => {
 		expect(withComment).toContain("dc-highlights");
 	});
 
+	// Regression for issue #30: once every comment is resolved and resolved
+	// comments are hidden, no card renders — so the column must not stay reserved.
+	test("all comments resolved + resolved hidden does not reserve the column", () => {
+		const hideResolved = commentConfig.of({
+			author: () => "me",
+			showComments: () => true,
+			showResolved: () => false,
+			sidebarOpen: () => false,
+		});
+		const openWith = (doc: string, cfg: typeof hideResolved): string => {
+			const parent = document.createElement("div");
+			document.body.appendChild(parent);
+			const view = new EditorView({
+				state: EditorState.create({ doc, extensions: [commentField, draftField, cfg, editorLayoutField] }),
+				parent,
+			});
+			view.requestMeasure();
+			const className = view.dom.className;
+			view.destroy();
+			return className;
+		};
+		const resolvedDoc = [
+			"Ship on <!--c:aaa-->Friday<!--/c:aaa--> regardless.",
+			'<!--co:aaa by:me at:2026-06-17T00:00:00.000Z status:resolved quote:"Friday"',
+			"me: done",
+			"-->",
+			"",
+		].join("\n");
+		// Sanity: with resolved shown, the (visible) resolved card still reserves the column.
+		expect(openWith(resolvedDoc, config)).toContain("dc-has");
+		// With resolved hidden, the card is display:none, so no column is reserved.
+		expect(openWith(resolvedDoc, hideResolved)).not.toContain("dc-has");
+	});
+
 	// Regression for issue #15: opening the transient "new comment" composer must
 	// NOT reserve the column. It used to toggle `dc-has`, which caps the sizer
 	// width and reflows/re-centers the whole document every time you start (and

--- a/test/editor-view.test.ts
+++ b/test/editor-view.test.ts
@@ -123,6 +123,21 @@ describe("editor extensions open every note without crashing", () => {
 		expect(openWith(resolvedDoc, config)).toContain("dc-has");
 		// With resolved hidden, the card is display:none, so no column is reserved.
 		expect(openWith(resolvedDoc, hideResolved)).not.toContain("dc-has");
+
+		// Mixed: one open + one resolved comment, resolved hidden. The open card
+		// still renders, so the column MUST stay reserved — guards the predicate
+		// against being written as `.every(...)` instead of `.some(...)`.
+		const mixedDoc = [
+			"Ship on <!--c:aaa-->Friday<!--/c:aaa--> and <!--c:bbb-->Monday<!--/c:bbb--> too.",
+			'<!--co:aaa by:me at:2026-06-17T00:00:00.000Z status:resolved quote:"Friday"',
+			"me: done",
+			"-->",
+			'<!--co:bbb by:me at:2026-06-17T00:00:01.000Z status:open quote:"Monday"',
+			"me: still open",
+			"-->",
+			"",
+		].join("\n");
+		expect(openWith(mixedDoc, hideResolved)).toContain("dc-has");
 	});
 
 	// Regression for issue #15: opening the transient "new comment" composer must


### PR DESCRIPTION
Closes #30.

## Problem
The in-line comment column keeps consuming ~320px of width even after every comment is resolved (with resolved comments hidden). Repro: open a doc with no comments (full width), add a comment (column appears), resolve it — the column persists with nothing visible in it.

## Cause
The column-reservation logic (the `dc-has` class that caps the text sizer's width) counted *any* comment with a body — including resolved ones. But resolved cards are `display:none` while resolved comments are hidden (`.dc-hide-resolved .doc-comment-card.is-resolved`, `styles.css:159-162`). So once every comment was resolved, all cards were hidden but the sizer still reserved the column over empty space.

This was present in **both** rendering paths:
- **Editor / source view** — `src/editor/layout.ts`, `hasColumn`
- **Reading view** — `src/reading/margin.ts`, `hasCards = this.comments.length > 0`

## Fix
Both paths now only reserve the column for comments whose card actually renders: a resolved comment reserves the column only when resolved comments are shown. The two guards are written identically.

Adds a regression test for the editor path (`test/editor-view.test.ts`) covering "all resolved + resolved hidden → no column". The reading-view path has no unit-test harness (its `ReadingMargin` needs the full Obsidian DOM, which isn't mocked in this repo), so that change is a direct mirror of the tested editor logic rather than independently tested.

`npm run check` passes (format, lint, typecheck, 42 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)