### PR TITLE
Address release review warnings

### DIFF
--- a/src/reading/highlight.ts
+++ b/src/reading/highlight.ts
@@ -77,8 +77,10 @@ const wrapFirstMatch = (root: HTMLElement, needle: string, id: string, resolved:
 			const range = doc.createRange();
 			range.setStart(node, idx);
 			range.setEnd(node, idx + needle.length);
-			const span = doc.createElement("span");
-			span.className = resolved ? "doc-comment-span is-resolved" : "doc-comment-span";
+			const span = root.createSpan({
+				cls: resolved ? "doc-comment-span is-resolved" : "doc-comment-span",
+			});
+			span.detach();
 			span.setAttribute("data-cid", id);
 			try {
 				range.surroundContents(span);

--- a/src/reading/margin.ts
+++ b/src/reading/margin.ts
@@ -206,8 +206,8 @@ class ReadingMargin {
 	/** Show an inline draft composer for a new comment (Reading-view "Add"). */
 	showDraft(from: number, to: number, range: Range): void {
 		this.clearDraft();
-		const span = this.scroller.ownerDocument.createElement("span");
-		span.className = "doc-comment-span dc-draft";
+		const span = this.scroller.createSpan({ cls: "doc-comment-span dc-draft" });
+		span.detach();
 		try {
 			range.surroundContents(span);
 		} catch {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
+import { App, PluginSettingTab, Setting, type SettingDefinitionItem } from "obsidian";
 import type DocCommentsPlugin from "./main";
 
 export type DocCommentsSettings = {
@@ -16,12 +16,69 @@ export const DEFAULT_SETTINGS: DocCommentsSettings = {
 	showResolved: false,
 };
 
+type DocCommentsSettingKey = keyof DocCommentsSettings;
+
 export class DocCommentsSettingTab extends PluginSettingTab {
 	constructor(
 		app: App,
 		private plugin: DocCommentsPlugin,
 	) {
 		super(app, plugin);
+	}
+
+	getSettingDefinitions(): SettingDefinitionItem<DocCommentsSettingKey>[] {
+		return [
+			{
+				name: "Author",
+				desc: 'Name attached to comments you create. Defaults to "me".',
+				aliases: ["comment author", "display name"],
+				control: {
+					type: "text",
+					key: "author",
+					defaultValue: DEFAULT_SETTINGS.author,
+					placeholder: "Me",
+				},
+			},
+			{
+				name: "Show comments",
+				desc: "Show the comment column. You can also toggle this from the ribbon or the command palette.",
+				aliases: ["comment column", "margin comments"],
+				control: {
+					type: "toggle",
+					key: "showComments",
+					defaultValue: DEFAULT_SETTINGS.showComments,
+				},
+			},
+			{
+				name: "Show resolved comments",
+				desc: "Keep resolved comments visible in the margin.",
+				aliases: ["resolved comments"],
+				control: {
+					type: "toggle",
+					key: "showResolved",
+					defaultValue: DEFAULT_SETTINGS.showResolved,
+				},
+			},
+		];
+	}
+
+	async setControlValue(key: string, value: unknown): Promise<void> {
+		switch (key) {
+			case "author":
+				this.plugin.settings.author = String(value);
+				await this.plugin.saveSettings();
+				break;
+			case "showComments":
+				this.plugin.settings.showComments = Boolean(value);
+				await this.plugin.saveSettings();
+				this.plugin.refreshEditors();
+				break;
+			case "showResolved":
+				this.plugin.settings.showResolved = Boolean(value);
+				await this.plugin.saveSettings();
+				this.plugin.refreshEditors();
+				break;
+		}
 	}
 
 	display(): void {

--- a/test/reading-highlight.test.ts
+++ b/test/reading-highlight.test.ts
@@ -9,6 +9,25 @@ import { describe, expect, test } from "vitest";
 import type { MarkdownPostProcessorContext } from "obsidian";
 import { highlightPostProcessor } from "../src/reading/highlight";
 
+Node.prototype.createSpan ??= function (o?: string | { cls?: string; text?: string; attr?: Record<string, string> }) {
+	const el = document.createElement("span");
+	if (typeof o === "string") {
+		el.className = o;
+	} else if (o) {
+		if (o.cls) el.className = o.cls;
+		if (o.text) el.textContent = o.text;
+		for (const [key, value] of Object.entries(o.attr ?? {})) {
+			el.setAttribute(key, value);
+		}
+	}
+	this.appendChild(el);
+	return el;
+};
+
+Node.prototype.detach ??= function () {
+	this.parentNode?.removeChild(this);
+};
+
 // Minimal context: report the block's source + line span, like Obsidian does.
 const ctxFor = (text: string, lineStart: number, lineEnd: number): MarkdownPostProcessorContext =>
 	({ getSectionInfo: () => ({ text, lineStart, lineEnd }) }) as unknown as MarkdownPostProcessorContext;


### PR DESCRIPTION
## What changed

- Replaced native reading-view span creation with Obsidian DOM helpers while preserving Range.surroundContents() behavior.
- Added declarative settings definitions so plugin settings are indexed by Obsidian 1.13 settings search.
- Kept the existing imperative settings renderer as the fallback path for older Obsidian versions.
- Added Happy DOM shims for the Obsidian DOM helpers used by the reading highlight tests.

## Why

- Fixes release review warnings for obsidianmd/prefer-create-el and missing getSettingDefinitions() support.

## Validation

- Independent Codex review agent found no actionable issues.
- npm run check passed: format, lint, typecheck, and all 42 tests.

## Notes

- The reported src/ui/card.ts:221-225 warning appears stale; that code already uses parent.createEl("span", ...).