### PR TITLE
Reveal comments from highlight clicks

### DIFF
--- a/src/editor/margin.ts
+++ b/src/editor/margin.ts
@@ -7,6 +7,7 @@ import { commentField } from "./state";
 import { commentConfig } from "./config";
 import { clearDraft, draftField } from "./draft";
 import { Card, CardCallbacks, CardView, cardSignature } from "../ui/card";
+import { visibleHighlightId } from "../ui/highlight-target";
 import {
 	addComment,
 	appendReply,
@@ -370,13 +371,9 @@ class MarginView implements PluginValue {
 	};
 
 	private onContentClick = (e: MouseEvent): void => {
-		const span = (e.target as HTMLElement).closest(".doc-comment-span");
-		if (!(span instanceof HTMLElement)) return;
-		const id = span?.getAttribute("data-cid");
-		if (!id) return;
 		const cfg = this.view.state.facet(commentConfig);
-		if (!cfg.showComments()) return;
-		if (span.classList.contains("is-resolved") && !cfg.showResolved()) return;
+		const id = visibleHighlightId(e.target, cfg.showComments(), cfg.showResolved());
+		if (!id) return;
 		e.preventDefault();
 		cfg.openInSidebar?.(id);
 	};

--- a/src/editor/margin.ts
+++ b/src/editor/margin.ts
@@ -85,6 +85,7 @@ class MarginView implements PluginValue {
 		this.resizeObserver = new ResizeObserver(() => this.requestReposition());
 		this.resizeObserver.observe(view.scrollDOM);
 		view.contentDOM.addEventListener("mousedown", this.onContentMouseDown);
+		view.contentDOM.addEventListener("click", this.onContentClick);
 		view.contentDOM.addEventListener("mouseover", this.onContentMouseOver);
 		view.contentDOM.addEventListener("mouseout", this.onContentMouseOut);
 
@@ -127,6 +128,7 @@ class MarginView implements PluginValue {
 		this.view.scrollDOM.removeEventListener("scroll", this.scrollHandler);
 		this.resizeObserver.disconnect();
 		this.view.contentDOM.removeEventListener("mousedown", this.onContentMouseDown);
+		this.view.contentDOM.removeEventListener("click", this.onContentClick);
 		this.view.contentDOM.removeEventListener("mouseover", this.onContentMouseOver);
 		this.view.contentDOM.removeEventListener("mouseout", this.onContentMouseOut);
 		this.removeDraftOutside();
@@ -365,6 +367,18 @@ class MarginView implements PluginValue {
 		const span = (e.target as HTMLElement).closest(".doc-comment-span");
 		const id = span?.getAttribute("data-cid");
 		if (id) this.setActive(id);
+	};
+
+	private onContentClick = (e: MouseEvent): void => {
+		const span = (e.target as HTMLElement).closest(".doc-comment-span");
+		if (!(span instanceof HTMLElement)) return;
+		const id = span?.getAttribute("data-cid");
+		if (!id) return;
+		const cfg = this.view.state.facet(commentConfig);
+		if (!cfg.showComments()) return;
+		if (span.classList.contains("is-resolved") && !cfg.showResolved()) return;
+		e.preventDefault();
+		cfg.openInSidebar?.(id);
 	};
 
 	private onContentMouseOver = (e: MouseEvent): void => {

--- a/src/editor/state.ts
+++ b/src/editor/state.ts
@@ -2,6 +2,7 @@ import { EditorState, Range, RangeSet, StateField } from "@codemirror/state";
 import { Decoration, DecorationSet, EditorView } from "@codemirror/view";
 import { ParsedComment } from "../format/types";
 import { anchorRange, parseComments } from "../format/parse";
+import { commentPreview } from "../format/preview";
 
 export type CommentFieldValue = {
 	comments: ParsedComment[];
@@ -64,7 +65,10 @@ const compute = (state: EditorState): CommentFieldValue => {
 			// a Live-Preview table (.cm-table-widget, a self-contained nested editor):
 			// the underlying text is hidden, so the highlight can't render there.
 			const cls = c.status === "resolved" ? "doc-comment-span is-resolved" : "doc-comment-span";
-			decoRanges.push(Decoration.mark({ class: cls, attributes: { "data-cid": c.id } }).range(r.from, r.to));
+			const attributes: Record<string, string> = { "data-cid": c.id };
+			const preview = commentPreview(c);
+			if (preview) attributes.title = preview;
+			decoRanges.push(Decoration.mark({ class: cls, attributes }).range(r.from, r.to));
 		}
 	}
 

--- a/src/format/preview.ts
+++ b/src/format/preview.ts
@@ -1,0 +1,9 @@
+import type { ParsedComment } from "./types";
+
+export const commentPreview = (comment: ParsedComment): string | null => {
+	const first = comment.thread[0];
+	const text = first?.text.trim().replace(/\s+/g, " ");
+	if (!text) return null;
+	const author = first.author || comment.author || "Comment";
+	return `${author}: ${text}`;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { ReadingDeps, ReadingMarginManager } from "./reading/margin";
 import { COMMENTS_VIEW_TYPE, CommentsSidebarView, SidebarDeps } from "./ui/sidebar";
 import { CommentModal } from "./ui/comment-modal";
 import { DEFAULT_SETTINGS, DocCommentsSettings, DocCommentsSettingTab } from "./settings";
+import { visibleHighlightId } from "./ui/highlight-target";
 
 export default class DocCommentsPlugin extends Plugin {
 	settings: DocCommentsSettings = { ...DEFAULT_SETTINGS };
@@ -66,6 +67,7 @@ export default class DocCommentsPlugin extends Plugin {
 			getAuthor: () => this.authorName(),
 		};
 		this.registerView(COMMENTS_VIEW_TYPE, (leaf) => new CommentsSidebarView(leaf, sidebarDeps));
+		if (Platform.isMobile) this.registerDomEvent(activeDocument, "click", this.onMobileHighlightClick, true);
 
 		this.registerMarkdownPostProcessor((el, ctx) => {
 			highlightPostProcessor(el, ctx);
@@ -280,6 +282,13 @@ export default class DocCommentsPlugin extends Plugin {
 		await this.activateSidebar();
 		await this.sidebarView()?.revealComment(id);
 	}
+
+	private onMobileHighlightClick = (event: MouseEvent): void => {
+		const id = visibleHighlightId(event.target, this.settings.showComments, this.settings.showResolved);
+		if (!id) return;
+		event.preventDefault();
+		void this.revealComment(id);
+	};
 
 	/** The live sidebar view instance, if the panel is open. */
 	private sidebarView(): CommentsSidebarView | null {

--- a/src/reading/highlight.ts
+++ b/src/reading/highlight.ts
@@ -1,6 +1,7 @@
 import { MarkdownPostProcessorContext } from "obsidian";
 import { ParsedComment } from "../format/types";
 import { anchorRange, parseComments } from "../format/parse";
+import { commentPreview } from "../format/preview";
 
 /** Rendered block element → its source range, so a Reading-view selection can be
  *  mapped back to markdown offsets (best-effort, used by "Add comment"). */
@@ -55,7 +56,7 @@ export const highlightPostProcessor = (el: HTMLElement, ctx: MarkdownPostProcess
 		// Only act on comments whose anchor starts within this rendered section.
 		if (range.from < sectionFrom || range.from >= sectionTo) continue;
 		const quote = text.slice(range.from, range.to);
-		if (quote.trim()) wrapFirstMatch(el, quote, c.id, c.status === "resolved");
+		if (quote.trim()) wrapFirstMatch(el, quote, c.id, c.status === "resolved", commentPreview(c));
 	}
 };
 
@@ -67,7 +68,13 @@ const offsetOfLine = (lines: string[], lineNo: number): number => {
 
 /** Wrap the first single-text-node occurrence of `needle` in a highlight span.
  *  Uses the element's own document so it works in pop-out windows too. */
-const wrapFirstMatch = (root: HTMLElement, needle: string, id: string, resolved: boolean): boolean => {
+const wrapFirstMatch = (
+	root: HTMLElement,
+	needle: string,
+	id: string,
+	resolved: boolean,
+	title: string | null,
+): boolean => {
 	const doc = root.ownerDocument;
 	const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
 	let node = walker.nextNode() as Text | null;
@@ -80,6 +87,7 @@ const wrapFirstMatch = (root: HTMLElement, needle: string, id: string, resolved:
 			const span = doc.createElement("span");
 			span.className = resolved ? "doc-comment-span is-resolved" : "doc-comment-span";
 			span.setAttribute("data-cid", id);
+			if (title) span.setAttribute("title", title);
 			try {
 				range.surroundContents(span);
 				return true;

--- a/src/reading/margin.ts
+++ b/src/reading/margin.ts
@@ -85,6 +85,7 @@ class ReadingMargin {
 		this.readingView.addEventListener("mouseover", this.onMouseOver);
 		this.readingView.addEventListener("mouseout", this.onMouseOut);
 		this.readingView.addEventListener("mousedown", this.onMouseDown);
+		this.readingView.addEventListener("click", this.onClick);
 	}
 
 	async refresh(text?: string): Promise<void> {
@@ -404,6 +405,17 @@ class ReadingMargin {
 		if (id) this.setActive(id);
 	};
 
+	private onClick = (e: MouseEvent): void => {
+		const span = (e.target as HTMLElement).closest(".doc-comment-span");
+		if (!(span instanceof HTMLElement)) return;
+		const id = span?.getAttribute("data-cid");
+		if (!id) return;
+		if (!this.deps.showComments()) return;
+		if (span.classList.contains("is-resolved") && !this.deps.showResolved()) return;
+		e.preventDefault();
+		this.deps.openInSidebar?.(id);
+	};
+
 	destroy(): void {
 		this.clearDraft();
 		this.scroller.removeEventListener("scroll", this.scrollHandler);
@@ -411,6 +423,7 @@ class ReadingMargin {
 		this.readingView.removeEventListener("mouseover", this.onMouseOver);
 		this.readingView.removeEventListener("mouseout", this.onMouseOut);
 		this.readingView.removeEventListener("mousedown", this.onMouseDown);
+		this.readingView.removeEventListener("click", this.onClick);
 		// The container we own goes away; the state classes sit on Obsidian's
 		// reading-view element, so clear them explicitly to avoid leaving it capped.
 		this.readingView.removeClasses(["dc-has", "dc-margin", "dc-highlights", "dc-hide-resolved"]);

--- a/src/reading/margin.ts
+++ b/src/reading/margin.ts
@@ -16,6 +16,7 @@ import {
 	computeToggleReaction,
 } from "../editor/edits";
 import { cssEscape } from "../util/css";
+import { visibleHighlightId } from "../ui/highlight-target";
 
 const CARD_GAP = 8;
 
@@ -406,12 +407,8 @@ class ReadingMargin {
 	};
 
 	private onClick = (e: MouseEvent): void => {
-		const span = (e.target as HTMLElement).closest(".doc-comment-span");
-		if (!(span instanceof HTMLElement)) return;
-		const id = span?.getAttribute("data-cid");
+		const id = visibleHighlightId(e.target, this.deps.showComments(), this.deps.showResolved());
 		if (!id) return;
-		if (!this.deps.showComments()) return;
-		if (span.classList.contains("is-resolved") && !this.deps.showResolved()) return;
 		e.preventDefault();
 		this.deps.openInSidebar?.(id);
 	};

--- a/src/ui/highlight-target.ts
+++ b/src/ui/highlight-target.ts
@@ -1,0 +1,11 @@
+export const visibleHighlightId = (
+	target: EventTarget | null,
+	showComments: boolean,
+	showResolved: boolean,
+): string | null => {
+	if (!showComments || !(target instanceof Element)) return null;
+	const span = target.closest(".doc-comment-span");
+	if (!(span instanceof HTMLElement)) return null;
+	if (span.classList.contains("is-resolved") && !showResolved) return null;
+	return span.getAttribute("data-cid");
+};

--- a/styles.css
+++ b/styles.css
@@ -67,6 +67,7 @@ body {
 	background-color: transparent;
 	border-bottom-color: transparent;
 	cursor: text;
+	pointer-events: none;
 }
 /* Likewise drop resolved highlights when resolved comments are hidden. */
 .cm-editor.dc-hide-resolved .doc-comment-span.is-resolved,
@@ -74,6 +75,7 @@ body {
 	background-color: transparent;
 	border-bottom-color: transparent;
 	cursor: text;
+	pointer-events: none;
 }
 .doc-comment-span.is-active {
 	background-color: var(--dc-highlight-bg-active);
@@ -566,4 +568,3 @@ body {
 	min-height: 5em;
 	resize: vertical;
 }
-

--- a/test/highlight-target.test.ts
+++ b/test/highlight-target.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment happy-dom
+import { describe, expect, test } from "vitest";
+import { visibleHighlightId } from "../src/ui/highlight-target";
+
+const highlight = (cls = "doc-comment-span"): HTMLElement => {
+	const span = document.createElement("span");
+	span.className = cls;
+	span.setAttribute("data-cid", "abc");
+	return span;
+};
+
+describe("visibleHighlightId", () => {
+	test("returns the comment id from a visible highlight or child target", () => {
+		const span = highlight();
+		const child = document.createElement("span");
+		span.appendChild(child);
+		expect(visibleHighlightId(span, true, true)).toBe("abc");
+		expect(visibleHighlightId(child, true, true)).toBe("abc");
+	});
+
+	test("ignores highlights while comments are hidden", () => {
+		expect(visibleHighlightId(highlight(), false, true)).toBeNull();
+	});
+
+	test("ignores resolved highlights while resolved comments are hidden", () => {
+		expect(visibleHighlightId(highlight("doc-comment-span is-resolved"), true, false)).toBeNull();
+	});
+});

--- a/test/reading-highlight.test.ts
+++ b/test/reading-highlight.test.ts
@@ -25,7 +25,9 @@ describe("reading-view highlight post-processor", () => {
 		const el = document.createElement("p");
 		el.textContent = "We ship on Friday regardless.";
 		highlightPostProcessor(el, ctxFor(doc, 0, 0));
-		expect(el.querySelector(".doc-comment-span[data-cid='p1']")?.textContent).toBe("Friday");
+		const span = el.querySelector(".doc-comment-span[data-cid='p1']");
+		expect(span?.textContent).toBe("Friday");
+		expect(span?.getAttribute("title")).toBe("me: ok");
 	});
 
 	test("wraps a comment anchor that lands inside a table cell", () => {


### PR DESCRIPTION
## What changed

- Adds hover preview text to editor and reading-view comment highlights.
- Opens and reveals the matching sidebar thread when a visible highlight is clicked.
- Keeps hidden comments inert when comments or resolved comments are hidden.

## Why

- Fixes #29 by making highlighted body text link back to the associated discussion instead of requiring users to hunt through the sidebar manually.

## Validation

- npm run check passed: format, lint, typecheck, and all 42 tests.